### PR TITLE
Set priority-based ordering for installers and seeders

### DIFF
--- a/DotNetBuddy.Example/Seeders/WeatherForecastSeeder.cs
+++ b/DotNetBuddy.Example/Seeders/WeatherForecastSeeder.cs
@@ -1,3 +1,4 @@
+using DotNetBuddy.Attributes;
 using DotNetBuddy.Example.Configs;
 using DotNetBuddy.Example.Models;
 using DotNetBuddy.Utilities;
@@ -5,6 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace DotNetBuddy.Example.Seeders;
 
+[SeedPriority(1000)]
 public class WeatherForecastSeeder(IOptions<WeatherForecastConfig> weatherForecastConfig, IUnitOfWork unitOfWork) : ISeeder
 {
     public string[] Environments =>

--- a/DotNetBuddy/Attributes/InstallPriorityAttribute.cs
+++ b/DotNetBuddy/Attributes/InstallPriorityAttribute.cs
@@ -7,7 +7,7 @@
 /// This attribute is intended to be applied to classes that implement the IInstaller interface,
 /// enabling control over the order in which installers are executed.
 /// Installers with higher weights will be executed after installers with lower weights.
-/// If the weight is not provided, the default value will be set to <c>int.MinValue</c>.
+/// If the weight is not provided, the default value will be set to <c>int.MaxValue</c>.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class InstallPriorityAttribute(int weight) : Attribute
@@ -19,7 +19,7 @@ public sealed class InstallPriorityAttribute(int weight) : Attribute
     /// The weight determines the execution order of installers during the dependency
     /// injection process. Installers with lower weight values will be executed first,
     /// followed by installers with higher weight values.
-    /// If no weight is specified, the default value is <c>int.MinValue</c>.
+    /// If no weight is specified, the default value is <c>int.MaxValue</c>.
     /// </remarks>
     public int Weight { get; } = weight;
 }

--- a/DotNetBuddy/Attributes/SeedPriorityAttribute.cs
+++ b/DotNetBuddy/Attributes/SeedPriorityAttribute.cs
@@ -1,0 +1,27 @@
+﻿namespace DotNetBuddy.Attributes;
+
+/// <summary>
+/// An attribute to specify a priority for seeders when being resolved or executed.
+/// Classes marked with this attribute will be processed relative to the weight specified,
+/// where lower values indicate higher priority.
+/// </summary>
+/// <remarks>
+/// This attribute is intended for use with classes implementing the <see cref="ISeeder"/> interface.
+/// It can be applied to influence the order in which seeders are resolved or executed during runtime.
+/// </remarks>
+/// <param name="weight">
+/// The priority weight of the seeder; lower values indicate higher priority.
+/// The default priority for seeders without this attribute is <see cref="int.MaxValue"/>.
+/// </param>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class SeedPriorityAttribute(int weight) : Attribute
+{
+    /// <summary>
+    /// Gets the priority weight assigned to a seeder.
+    /// </summary>
+    /// <remarks>
+    /// The weight determines the priority of a seeder where lower values have higher priority.
+    /// Seeders without a specified weight default to <see cref="int.MaxValue"/>.
+    /// </remarks>
+    public int Weight { get; } = weight;
+}

--- a/DotNetBuddy/Extensions/ServiceCollectionExtensions.cs
+++ b/DotNetBuddy/Extensions/ServiceCollectionExtensions.cs
@@ -64,11 +64,11 @@ public static class ServiceCollectionExtensions
                     return new
                     {
                         Type = t,
-                        Priority = attr?.Weight ?? int.MinValue
+                        Priority = attr?.Weight ?? int.MaxValue
                     };
                 }
             )
-            .OrderByDescending(x => x.Priority)
+            .OrderBy(x => x.Priority)
             .Select(x => (IInstaller)Activator.CreateInstance(x.Type!)!);
 
         foreach (var installer in installers)

--- a/DotNetBuddy/Installers/ConfigInstaller.cs
+++ b/DotNetBuddy/Installers/ConfigInstaller.cs
@@ -15,7 +15,7 @@ namespace DotNetBuddy.Installers;
 /// their names, binding them to related configuration sections, and validating
 /// them both via data annotations and at application startup.
 /// </remarks>
-[InstallPriority(900000)]
+[InstallPriority(1000)]
 public class ConfigInstaller : IInstaller
 {
     /// <summary>

--- a/DotNetBuddy/Installers/ExceptionsInstaller.cs
+++ b/DotNetBuddy/Installers/ExceptionsInstaller.cs
@@ -11,7 +11,7 @@ namespace DotNetBuddy.Installers;
 /// injection container, including customization of problem details
 /// for enhanced error diagnostics.
 /// </summary>
-[InstallPriority(500000)]
+[InstallPriority(2000)]
 public class ExceptionsInstaller : IInstaller
 {
     /// <summary>

--- a/DotNetBuddy/Installers/FiltersInstaller.cs
+++ b/DotNetBuddy/Installers/FiltersInstaller.cs
@@ -14,7 +14,7 @@ namespace DotNetBuddy.Installers;
 /// and adds a custom validation filter, <see cref="ModelStateValidationFilter"/>,
 /// to be applied globally to all MVC actions.
 /// </remarks>
-[InstallPriority(500000)]
+[InstallPriority(3000)]
 public class FiltersInstaller : IInstaller
 {
     /// <summary>

--- a/DotNetBuddy/Installers/InterceptorsInstallers.cs
+++ b/DotNetBuddy/Installers/InterceptorsInstallers.cs
@@ -10,7 +10,7 @@ namespace DotNetBuddy.Installers;
 /// <remarks>
 /// This installer registers services related to database operation interceptors, such as auditing functionality.
 /// </remarks>
-[InstallPriority(700000)]
+[InstallPriority(3000)]
 public class InterceptorsInstallers : IInstaller
 {
     /// <summary>


### PR DESCRIPTION
### Description of Changes

- Added `SeedPriorityAttribute` for prioritizing seeder execution.
- Updated `InstallPriorityAttribute` default behavior to use `int.MaxValue`.
- Adjusted priorities for installers and seeders to enable consistent execution order based on priority values.
- Enhanced clarity and flexibility in dependency resolution logic.
