### PR TITLE
Improve ID comparisons and add GetWeatherForecast endpoint

### DIFF
--- a/DotNetBuddy.Example/Controllers/WeatherForecastController.cs
+++ b/DotNetBuddy.Example/Controllers/WeatherForecastController.cs
@@ -15,6 +15,17 @@ public class WeatherForecastController(IExtendedUnitOfWork extendedUnitOfWork) :
         return await extendedUnitOfWork.WeatherForecasts.GetAllAsync();
     }
 
+    [HttpGet("GetWeatherForecast/{id:guid}")]
+    public async Task<WeatherForecast> GetWeatherForecast(Guid id)
+    {
+        var weatherForecast = await extendedUnitOfWork.WeatherForecasts.GetAsync(id);
+
+        if (weatherForecast is null)
+            throw new BuddyException("NotFound", "Weather forecast not found.", StatusCodes.Status404NotFound);
+
+        return weatherForecast;
+    }
+
     [HttpGet("GetException")]
     public Task GetException()
     {

--- a/DotNetBuddy.Infrastructure/Repositories/Repository.cs
+++ b/DotNetBuddy.Infrastructure/Repositories/Repository.cs
@@ -65,8 +65,7 @@ public class Repository<T, TKey>(DbContext context) : IRepository<T, TKey> where
             (current, include) => current.Include(include)
         );
 
-        return await ApplyQueryOptions(query, options)
-            .FirstOrDefaultAsync(x => EqualityComparer<TKey>.Default.Equals(x.Id, id));
+        return await ApplyQueryOptions(query, options).FirstOrDefaultAsync(x => x.Id!.Equals(id));
     }
 
     /// <inheritdoc />
@@ -78,7 +77,7 @@ public class Repository<T, TKey>(DbContext context) : IRepository<T, TKey> where
     /// <inheritdoc />
     public async Task<bool> AnyAsync(TKey id, QueryOptions options = QueryOptions.None)
     {
-        return await ApplyQueryOptions(DbSet, options).AnyAsync(x => EqualityComparer<TKey>.Default.Equals(x.Id, id));
+        return await ApplyQueryOptions(DbSet, options).AnyAsync(x => x.Id!.Equals(id));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Updated ID comparisons in repository methods to handle nullable IDs more robustly by replacing `EqualityComparer` with direct `.Equals()` calls. Added a new `GetWeatherForecast` endpoint in the WeatherForecastController to retrieve a single weather forecast by its GUID, including appropriate error handling for not found cases.