### PR TITLE
Update default `InstallPriorityAttribute` value to `int.MinValue`

### DIFF
--- a/DotNetBuddy.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/DotNetBuddy.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -55,7 +55,7 @@ public static class ServiceCollectionExtensions
                     return new
                     {
                         Type = t,
-                        Priority = attr?.Priority ?? int.MaxValue
+                        Priority = attr?.Priority ?? int.MinValue
                     };
                 }
             )


### PR DESCRIPTION
- Adjusted default priority to `int.MinValue` instead of `int.MaxValue` for more consistent installer execution order.