### PR TITLE
Update README.md for consistency with renamed EF Core extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ It encourages clean architecture principles and supports out-of-the-box patterns
 
 ## 📦 NuGet Packages
 
-| Project                                        | Version                                                                                                                                                   | Downloads                                                                                                                                                      |
-|------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **DotNetBuddy.Domain**                         | [![NuGet](https://img.shields.io/nuget/v/DotNetBuddy.Domain?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Domain/)                       | [![Downloads](https://img.shields.io/nuget/dt/DotNetBuddy.Domain?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Domain/)                       |
-| **DotNetBuddy.Application**                    | [![NuGet](https://img.shields.io/nuget/v/DotNetBuddy.Application?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Application/)             | [![Downloads](https://img.shields.io/nuget/dt/DotNetBuddy.Application?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Application/)             |
-| **DotNetBuddy.Infrastructure**                 | [![NuGet](https://img.shields.io/nuget/v/DotNetBuddy.Infrastructure?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Infrastructure/)       | [![Downloads](https://img.shields.io/nuget/dt/DotNetBuddy.Infrastructure?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Infrastructure/)       |
-| **DotNetBuddy.Presentation**                   | [![NuGet](https://img.shields.io/nuget/v/DotNetBuddy.Presentation?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Presentation/)           | [![Downloads](https://img.shields.io/nuget/dt/DotNetBuddy.Presentation?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Presentation/)           |
-| **DotNetBuddy.Extensions.EfCore** | [![NuGet](https://img.shields.io/nuget/v/DotNetBuddy.Extensions.EfCore?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Extensions.EfCore/) | [![Downloads](https://img.shields.io/nuget/dt/DotNetBuddy.Extensions.EfCore?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Extensions.EfCore/) |
+| Project                                        | Version                                                                                                                                                                | Downloads                                                                                                                                                      |
+|------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **DotNetBuddy.Domain**                         | [![NuGet](https://img.shields.io/nuget/v/DotNetBuddy.Domain?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Domain/)                                    | [![Downloads](https://img.shields.io/nuget/dt/DotNetBuddy.Domain?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Domain/)                       |
+| **DotNetBuddy.Application**                    | [![NuGet](https://img.shields.io/nuget/v/DotNetBuddy.Application?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Application/)                          | [![Downloads](https://img.shields.io/nuget/dt/DotNetBuddy.Application?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Application/)             |
+| **DotNetBuddy.Infrastructure**                 | [![NuGet](https://img.shields.io/nuget/v/DotNetBuddy.Infrastructure?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Infrastructure/)                    | [![Downloads](https://img.shields.io/nuget/dt/DotNetBuddy.Infrastructure?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Infrastructure/)       |
+| **DotNetBuddy.Presentation**                   | [![NuGet](https://img.shields.io/nuget/v/DotNetBuddy.Presentation?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Presentation/)                        | [![Downloads](https://img.shields.io/nuget/dt/DotNetBuddy.Presentation?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Presentation/)           |
+| **DotNetBuddy.Extensions.EntityFrameworkCore** | [![NuGet](https://img.shields.io/nuget/v/DotNetBuddy.Extensions.EntityFrameworkCore?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Extensions.EntityFrameworkCore/) | [![Downloads](https://img.shields.io/nuget/dt/DotNetBuddy.Extensions.EntityFrameworkCore?style=flat-square)](https://www.nuget.org/packages/DotNetBuddy.Extensions.EntityFrameworkCore/) |
 
 ## Quick Start
 
@@ -82,7 +82,7 @@ Or allow seeders to run on boot:
 - [Exception Handling](./Docs/Exceptions.md)
 - [Installers](./Docs/Installers.md)
 
-## Extension: EfCore
+## Extension: EntityFrameworkCore
 - [Audit System](./Docs/Audit.md)
 - [Database Access](./Docs/Database.md)
 - [Data Seeding](./Docs/Seeders.md)


### PR DESCRIPTION
- Renamed `EfCore` references to `EntityFrameworkCore` to match updated project naming.
- Adjusted table and section titles for clarity and alignment with conventions.