### PR TITLE
Update `InstallPriorityAttribute` and `SeedPriorityAttribute` to use …

### DIFF
--- a/DotNetBuddy.Domain/Attributes/InstallPriorityAttribute.cs
+++ b/DotNetBuddy.Domain/Attributes/InstallPriorityAttribute.cs
@@ -6,8 +6,8 @@
 /// <remarks>
 /// This attribute is used to annotate classes that participate in the installation process,
 /// allowing their execution order to be determined based on a specified priority value.
-/// Classes with lower priority values will be executed earlier, and the default priority is set
-/// to <c>Int32.MaxValue</c> if no specific value is provided.
+/// Classes with a higher priority value will be executed earlier, and the default priority is set
+/// to <c>Int32.MinValue</c> if no specific value is provided.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class InstallPriorityAttribute(int priority) : Attribute
@@ -16,9 +16,9 @@ public sealed class InstallPriorityAttribute(int priority) : Attribute
     /// Gets the priority level assigned to determine the execution order of an installer.
     /// </summary>
     /// <remarks>
-    /// Installers with a lower priority value will execute earlier during the dependency injection
-    /// process, while those with higher priority values will execute later. If no priority is explicitly
-    /// assigned, the default value is <c>int.MaxValue</c>.
+    /// Installers with a higher priority value will execute earlier during the dependency injection
+    /// process, while those with lower priority values will execute later. If no priority is explicitly
+    /// assigned, the default value is <c>int.MinValue</c>.
     /// </remarks>
     public int Priority { get; } = priority;
 }

--- a/DotNetBuddy.Domain/Attributes/SeedPriorityAttribute.cs
+++ b/DotNetBuddy.Domain/Attributes/SeedPriorityAttribute.cs
@@ -9,8 +9,8 @@
 /// The priority defined by this attribute helps determine the order of execution for multiple seeders.
 /// </remarks>
 /// <param name="priority">
-/// The numeric value representing the priority of the seeder. Lower values indicate higher priority.
-/// If a seeder class does not have this attribute, it will default to a priority of <see cref="int.MaxValue"/>.
+/// The numeric value representing the priority of the seeder. Higher values indicate higher priority.
+/// If a seeder class does not have this attribute, it will default to a priority of <see cref="int.MinValue"/>.
 /// </param>
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class SeedPriorityAttribute(int priority) : Attribute
@@ -19,7 +19,7 @@ public sealed class SeedPriorityAttribute(int priority) : Attribute
     /// Gets the priority weight assigned to a seed operation or handler.
     /// </summary>
     /// Priority is used to determine the order in which seeders are executed or resolved,
-    /// with lower values indicating higher priority. If no priority is specified,
-    /// the default value is <see cref="int.MaxValue"/>.
+    /// with higher values indicating higher priority. If no priority is specified,
+    /// the default value is <see cref="int.MinValue"/>.
     public int Priority { get; } = priority;
 }


### PR DESCRIPTION
…`int.MinValue` as default priority (#25)

- Modified priority rules to specify that higher values indicate higher priority.
- Updated default priority to `int.MinValue` for consistency in execution order documentation.