### PR TITLE
Add hard delete and domain-specific exception handling

### DIFF
--- a/DotNetBuddy.Domain/Exceptions/BuddyException.cs
+++ b/DotNetBuddy.Domain/Exceptions/BuddyException.cs
@@ -1,0 +1,10 @@
+﻿namespace DotNetBuddy.Domain.Exceptions;
+
+/// <summary>
+/// Represents a custom exception specific to the DotNetBuddy domain.
+/// </summary>
+/// <remarks>
+/// This exception is used for handling errors that occur within the application,
+/// providing meaningful and domain-specific exception messages.
+/// </remarks>
+public class BuddyException(string message) : Exception(message);

--- a/DotNetBuddy.Domain/Exceptions/BuddyHttpException.cs
+++ b/DotNetBuddy.Domain/Exceptions/BuddyHttpException.cs
@@ -1,6 +1,4 @@
-using DotNetBuddy.Domain.Exceptions;
-
-namespace DotNetBuddy.Domain;
+namespace DotNetBuddy.Domain.Exceptions;
 
 /// <summary>
 /// Represents a custom exception specific to the BuddyDotNet platform.
@@ -14,5 +12,5 @@ namespace DotNetBuddy.Domain;
 /// This exception can be thrown when application-specific errors occur, providing meaningful
 /// context such as a human-readable title, error message, and the relevant HTTP status code.
 /// </example>
-public class BuddyException(string title, string detail, int statusCode = 400)
+public class BuddyHttpException(string title, string detail, int statusCode = 400)
     : Rfc9110Exception(title, detail, statusCode);

--- a/DotNetBuddy.Domain/IRepository.cs
+++ b/DotNetBuddy.Domain/IRepository.cs
@@ -183,15 +183,17 @@ public interface IRepository<T, TKey> where T : class, IEntity<TKey>
     /// Deletes an entity from the repository based on its unique identifier.
     /// </summary>
     /// <param name="id">The unique identifier of the entity to be deleted.</param>
+    /// <param name="forceHardDelete">A flag indicating whether the deletion should be a hard delete. If set to true, the entity is permanently removed. Defaults to false, which performs a soft delete if supported.</param>
     /// <returns>A task that represents the asynchronous deletion operation.</returns>
-    Task DeleteAsync(TKey id);
+    Task DeleteAsync(TKey id, bool forceHardDelete = false);
 
     /// <summary>
     /// Deletes a range of entities from the repository identified by their unique keys.
     /// </summary>
     /// <param name="ids">A collection of unique identifiers corresponding to the entities to be deleted.</param>
+    /// <param name="forceHardDelete">Indicates whether to perform a hard delete, bypassing soft delete mechanisms. Defaults to false.</param>
     /// <returns>A task that represents the asynchronous operation of deleting the specified entities.</returns>
-    Task DeleteRangeAsync(IEnumerable<TKey> ids);
+    Task DeleteRangeAsync(IEnumerable<TKey> ids, bool forceHardDelete = false);
 
     /// <summary>
     /// Counts the total number of entities in the repository that match the specified predicate.

--- a/DotNetBuddy.Example.Tests/DotNetBuddy.Example.Tests.csproj
+++ b/DotNetBuddy.Example.Tests/DotNetBuddy.Example.Tests.csproj
@@ -10,7 +10,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.15" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="xunit" Version="2.5.3"/>

--- a/DotNetBuddy.Example/Controllers/WeatherForecastController.cs
+++ b/DotNetBuddy.Example/Controllers/WeatherForecastController.cs
@@ -1,4 +1,4 @@
-using DotNetBuddy.Domain;
+using DotNetBuddy.Domain.Exceptions;
 using DotNetBuddy.Example.Models;
 using DotNetBuddy.Example.Repositories.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -20,16 +20,14 @@ public class WeatherForecastController(IExtendedUnitOfWork extendedUnitOfWork) :
     {
         var weatherForecast = await extendedUnitOfWork.WeatherForecasts.GetAsync(id);
 
-        if (weatherForecast is null)
-            throw new BuddyException("NotFound", "Weather forecast not found.", StatusCodes.Status404NotFound);
-
-        return weatherForecast;
+        return weatherForecast ??
+               throw new BuddyHttpException("NotFound", "Weather forecast not found.", StatusCodes.Status404NotFound);
     }
 
     [HttpGet("GetException")]
     public Task GetException()
     {
-        throw new BuddyException("This is a test exception", "Test", StatusCodes.Status418ImATeapot);
+        throw new BuddyHttpException("This is a test exception", "Test", StatusCodes.Status418ImATeapot);
     }
 
     [HttpGet("Crash")]

--- a/DotNetBuddy.Extensions.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/DotNetBuddy.Extensions.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -27,6 +27,9 @@ public static class ModelBuilderExtensions
             if (!isSoftDeletable)
                 continue;
 
+            if (entityType.BaseType != null) 
+                continue;
+            
             var interfaceType = clrType.GetInterfaces()
                 .First(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ISoftDeletableEntity<>));
             var deletedAtProperty = interfaceType.GetProperty(nameof(ISoftDeletableEntity<object>.DeletedAt));

--- a/DotNetBuddy.Extensions.EntityFrameworkCore/Extensions/QueryableExtensions.cs
+++ b/DotNetBuddy.Extensions.EntityFrameworkCore/Extensions/QueryableExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq.Expressions;
-using DotNetBuddy.Domain;
 using DotNetBuddy.Domain.Enums;
+using DotNetBuddy.Domain.Exceptions;
 using DotNetBuddy.Infrastructure.Utilities;
 using Microsoft.EntityFrameworkCore;
 
@@ -61,11 +61,7 @@ public static class QueryableExtensions
         if (options.HasFlag(QueryOptions.AsNoTracking) &&
             options.HasFlag(QueryOptions.AsNoTrackingWithIdentityResolution))
         {
-            throw new BuddyException
-            (
-                "Invalid query options.",
-                "Cannot specify both AsNoTracking and AsNoTrackingWithIdentityResolution."
-            );
+            throw new BuddyException("Cannot specify both AsNoTracking and AsNoTrackingWithIdentityResolution.");
         }
 
         if (options.HasFlag(QueryOptions.AsNoTracking))

--- a/DotNetBuddy.Tests/DotNetBuddy.Tests.csproj
+++ b/DotNetBuddy.Tests/DotNetBuddy.Tests.csproj
@@ -10,8 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.16" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.16"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="xunit" Version="2.5.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
@@ -22,9 +21,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\DotNetBuddy.Extensions.EntityFrameworkCore\DotNetBuddy.Extensions.EntityFrameworkCore.csproj" />
-      <ProjectReference Include="..\DotNetBuddy.Domain\DotNetBuddy.Domain.csproj" />
-      <ProjectReference Include="..\DotNetBuddy.Infrastructure\DotNetBuddy.Infrastructure.csproj" />
+        <ProjectReference Include="..\DotNetBuddy.Extensions.EntityFrameworkCore\DotNetBuddy.Extensions.EntityFrameworkCore.csproj"/>
+        <ProjectReference Include="..\DotNetBuddy.Domain\DotNetBuddy.Domain.csproj"/>
+        <ProjectReference Include="..\DotNetBuddy.Infrastructure\DotNetBuddy.Infrastructure.csproj"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Added a `forceHardDelete` parameter to `DeleteAsync` and `DeleteRangeAsync` to allow flexibility between soft and hard deletes.
- Introduced `BuddyException` and `BuddyHttpException` for meaningful domain-specific exception management.
- Updated `ModelBuilderExtensions` to skip entities with base types for soft deletable behavior configuration.
- Removed unused `coverlet.collector` package references from test projects.