### PR TITLE
Convert validation methods to asynchronous and update related tests a…

### DIFF
--- a/DotNetBuddy.Domain/IValidationService.cs
+++ b/DotNetBuddy.Domain/IValidationService.cs
@@ -14,8 +14,10 @@ public interface IValidationService
     /// <typeparam name="TInput">The type of the input object used for validation. Must be a reference type.</typeparam>
     /// <param name="source">The source object to validate.</param>
     /// <param name="input">The input object used for validation.</param>
-    /// <returns>A collection of <see cref="ValidationResult"/> objects containing validation results. Returns an empty collection if no validator is registered or if no validation errors are found.</returns>
-    IEnumerable<ValidationResult> Validate<TSource, TInput>(TSource source, TInput input)
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>An asynchronous stream of <see cref="ValidationResult"/> objects containing validation results. Returns an empty stream if no validator is registered or if no validation errors are found.</returns>
+    IAsyncEnumerable<ValidationResult> ValidateAsync<TSource, TInput>(TSource source, TInput input,
+        CancellationToken cancellationToken = default)
         where TSource : class where TInput : class;
 
     /// <summary>
@@ -26,6 +28,8 @@ public interface IValidationService
     /// <typeparam name="TInput">The type of the input object used for validation. Must be a reference type.</typeparam>
     /// <param name="source">The source object to validate.</param>
     /// <param name="input">The input object used for validation.</param>
-    /// <returns>A collection of <see cref="ValidationResult"/> objects containing validation results. If any validation errors are found, an exception is thrown, and this method does not return normally.</returns>
-    void ValidateOrThrow<TSource, TInput>(TSource source, TInput input) where TSource : class where TInput : class;
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous operation. If any validation errors are found, an exception is thrown, and this task does not complete successfully.</returns>
+    Task ValidateOrThrowAsync<TSource, TInput>(TSource source, TInput input,
+        CancellationToken cancellationToken = default) where TSource : class where TInput : class;
 }

--- a/DotNetBuddy.Domain/IValidator.cs
+++ b/DotNetBuddy.Domain/IValidator.cs
@@ -15,8 +15,6 @@ public interface IValidator<in TSource, in TInput> where TSource : class where T
     /// <param name="source">The source object to be validated.</param>
     /// <param name="input">The input object containing the validation criteria.</param>
     /// <param name="cancellationToken">An optional token to observe for cancellation requests.</param>
-    /// <typeparam name="TSource">The type of the source object to validate, must be a reference type.</typeparam>
-    /// <typeparam name="TInput">The type of the input object used for validation, must be a reference type.</typeparam>
     /// <returns>A collection of <see cref="ValidationResult"/> objects that represent the results of validation.
     /// If no validator is registered, or if no validation errors occur, an empty collection is returned.</returns>
     IAsyncEnumerable<ValidationResult> ValidateAsync(TSource source, TInput input,

--- a/DotNetBuddy.Domain/IValidator.cs
+++ b/DotNetBuddy.Domain/IValidator.cs
@@ -10,11 +10,15 @@ namespace DotNetBuddy.Domain;
 public interface IValidator<in TSource, in TInput> where TSource : class where TInput : class
 {
     /// <summary>
-    /// Validates the provided source object against the input parameters using a registered validator.
+    /// Validates the provided source object against the input parameters using a registered validator service.
     /// </summary>
     /// <param name="source">The source object to be validated.</param>
-    /// <param name="input">The input parameters against which the source object is validated.</param>
-    /// <returns>A collection of <see cref="ValidationResult"/> objects containing validation results.
-    /// Returns an empty collection if no validator is registered or no validation errors occur.</returns>
-    IEnumerable<ValidationResult> Validate(TSource source, TInput input);
+    /// <param name="input">The input object containing the validation criteria.</param>
+    /// <param name="cancellationToken">An optional token to observe for cancellation requests.</param>
+    /// <typeparam name="TSource">The type of the source object to validate, must be a reference type.</typeparam>
+    /// <typeparam name="TInput">The type of the input object used for validation, must be a reference type.</typeparam>
+    /// <returns>A collection of <see cref="ValidationResult"/> objects that represent the results of validation.
+    /// If no validator is registered, or if no validation errors occur, an empty collection is returned.</returns>
+    IAsyncEnumerable<ValidationResult> ValidateAsync(TSource source, TInput input,
+        CancellationToken cancellationToken = default);
 }

--- a/DotNetBuddy.Example/Controllers/WeatherForecastController.cs
+++ b/DotNetBuddy.Example/Controllers/WeatherForecastController.cs
@@ -24,7 +24,7 @@ public class WeatherForecastController(IExtendedUnitOfWork extendedUnitOfWork, I
             cancellationToken: cancellationToken
         ) ?? throw new NotFoundException("Weather forecast not found.");
 
-        validationService.ValidateOrThrow(weatherForecast, dto);
+        await validationService.ValidateOrThrowAsync(weatherForecast, dto, cancellationToken);
         MapDtoIntoEntity(ref weatherForecast, dto);
 
         extendedUnitOfWork.WeatherForecasts.UpdateShallow(weatherForecast);

--- a/DotNetBuddy.Example/Validators/WeatherForecastUpdateValidator.cs
+++ b/DotNetBuddy.Example/Validators/WeatherForecastUpdateValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
 using DotNetBuddy.Domain;
 using DotNetBuddy.Example.Contracts;
 using DotNetBuddy.Example.Entities;
@@ -7,7 +8,8 @@ namespace DotNetBuddy.Example.Validators;
 
 public class WeatherForecastUpdateValidator : IValidator<WeatherForecast, WeatherForecastUpdateDto>
 {
-    public IEnumerable<ValidationResult> Validate(WeatherForecast source, WeatherForecastUpdateDto input)
+    public async IAsyncEnumerable<ValidationResult> ValidateAsync(WeatherForecast source,
+        WeatherForecastUpdateDto input, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         if (source.TemperatureC < input.TemperatureC)
             yield return new ValidationResult("Temperature cannot be greater than the original value.",
@@ -16,5 +18,7 @@ public class WeatherForecastUpdateValidator : IValidator<WeatherForecast, Weathe
         if (source.Summary == input.Summary)
             yield return new ValidationResult("Summary cannot be the same as the original value.",
                 [nameof(input.Summary)]);
+
+        await Task.CompletedTask;
     }
 }

--- a/DotNetBuddy.Tests/Unit/ValidationServiceTests.cs
+++ b/DotNetBuddy.Tests/Unit/ValidationServiceTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using DotNetBuddy.Application.Services;
 using DotNetBuddy.Domain;
 using DotNetBuddy.Tests.Entities;
@@ -17,7 +18,7 @@ public class ValidationServiceTests
     }
 
     [Fact]
-    public void Validate_WhenNoValidatorRegistered_ReturnsEmptyCollection()
+    public async Task Validate_WhenNoValidatorRegistered_ReturnsEmptyCollection()
     {
         // Arrange: build provider without registering any validator
         var services = new ServiceCollection();
@@ -29,17 +30,21 @@ public class ValidationServiceTests
         var input = new ComplexEntity { Id = source.Id, BaseValue = 1, BelowBaseValue = 2, UnchangeableValue = 8 };
 
         // Act
-        var results = service.Validate(source, input).ToList();
+        var results = new List<ValidationResult>();
+        await foreach (var result in service.ValidateAsync(source, input))
+        {
+            results.Add(result);
+        }
 
         // Assert
         Assert.Empty(results);
     }
 
     [Fact]
-    public void Validate_WithRegisteredValidator_ReturnsExpectedFailures()
+    public async Task Validate_WithRegisteredValidator_ReturnsExpectedFailures()
     {
         // Arrange
-        using var provider = BuildProviderWithValidator();
+        await using var provider = BuildProviderWithValidator();
         var service = provider.GetRequiredService<IValidationService>();
 
         var source = new ComplexEntity { Id = Guid.NewGuid(), BaseValue = 10, BelowBaseValue = 5, UnchangeableValue = 7 };
@@ -49,7 +54,11 @@ public class ValidationServiceTests
         var input = new ComplexEntity { Id = source.Id, BaseValue = 3, BelowBaseValue = 9, UnchangeableValue = 8 };
 
         // Act
-        var results = service.Validate(source, input).ToList();
+        var results = new List<ValidationResult>();
+        await foreach (var result in service.ValidateAsync(source, input))
+        {
+            results.Add(result);
+        }
 
         // Assert
         Assert.Equal(2, results.Count);
@@ -58,17 +67,21 @@ public class ValidationServiceTests
     }
 
     [Fact]
-    public void Validate_WithValidInput_ReturnsEmpty()
+    public async Task Validate_WithValidInput_ReturnsEmpty()
     {
         // Arrange
-        using var provider = BuildProviderWithValidator();
+        await using var provider = BuildProviderWithValidator();
         var service = provider.GetRequiredService<IValidationService>();
 
         var source = new ComplexEntity { Id = Guid.NewGuid(), BaseValue = 10, BelowBaseValue = 5, UnchangeableValue = 7 };
         var input = new ComplexEntity { Id = source.Id, BaseValue = 9, BelowBaseValue = 4, UnchangeableValue = 7 };
 
         // Act
-        var results = service.Validate(source, input).ToList();
+        var results = new List<ValidationResult>();
+        await foreach (var result in service.ValidateAsync(source, input))
+        {
+            results.Add(result);
+        }
 
         // Assert
         Assert.Empty(results);

--- a/DotNetBuddy.Tests/Validators/ComplexEntityUpdateValidator.cs
+++ b/DotNetBuddy.Tests/Validators/ComplexEntityUpdateValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
 using DotNetBuddy.Domain;
 using DotNetBuddy.Tests.Entities;
 
@@ -6,7 +7,8 @@ namespace DotNetBuddy.Tests.Validators;
 
 public class ComplexEntityUpdateValidator : IValidator<ComplexEntity, ComplexEntity>
 {
-    public IEnumerable<ValidationResult> Validate(ComplexEntity source, ComplexEntity input)
+    public async IAsyncEnumerable<ValidationResult> ValidateAsync(ComplexEntity source, ComplexEntity input,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         if (source.UnchangeableValue != input.UnchangeableValue)
         {
@@ -21,5 +23,7 @@ public class ComplexEntityUpdateValidator : IValidator<ComplexEntity, ComplexEnt
             yield return new ValidationResult("Bar is not allowed to be greater than Foo.",
                 [nameof(input.BelowBaseValue)]);
         }
+
+        await Task.CompletedTask;
     }
 }


### PR DESCRIPTION
…nd validators

- Replaced all synchronous validation methods with asynchronous variants (`ValidateAsync` and `ValidateOrThrowAsync`) across the solution.
- Updated `IValidationService` and `IValidator<TSource, TInput>` interfaces to support async operations with cancellation tokens.
- Refactored `WeatherForecastController` and `ValidationService` to use the updated async validation methods.
- Modified unit tests to support asynchronous validation workflows (`ValidateAsync` and `ValidateOrThrowAsync`).
- Updated `ComplexEntityUpdateValidator` and `WeatherForecastUpdateValidator` to provide async implementations using `IAsyncEnumerable`.